### PR TITLE
Fix mashers needing to be hit to their maximum to not count as a miss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains project settings
+.idea/

--- a/MuseDashInfo+/Managers/GameStatsManager.cs
+++ b/MuseDashInfo+/Managers/GameStatsManager.cs
@@ -35,7 +35,7 @@ public static class GameStatsManager
     private static HashSet<int> MissedNoteIds = new();
 
     private static MusicData MashingNote;
-    private static int MashedNum = -1;
+    private static int MashedNum = 0;
 
     public record struct CurrentStats(
         int Perfect, int Great, int Early, int Late, int Music, int Energy, int Block, int RedPoint,
@@ -257,7 +257,7 @@ public static class GameStatsManager
     public static void ResetMashing()
     {
         MashingNote = null;
-        MashedNum = -1;
+        MashedNum = 0;
     }
 
     public static void CheckMashing()
@@ -266,9 +266,11 @@ public static class GameStatsManager
         bool timesup = _stage.realTimeTick > (MashingNote.tick + MashingNote.configData.length) * 1000;
         if (timesup)
         {
-            bool reachHigh = MashedNum >= MashingNote.GetMulHitHighThreshold();
-            if (!reachHigh && !MissedNoteIds.Contains(int.Parse(MashingNote.noteData.id)))
+            bool tooLow = MashedNum < MashingNote.GetMulHitLowThreshold();
+
+            if (tooLow && !MissedNoteIds.Contains(int.Parse(MashingNote.noteData.id)))
                 _miss.Mul++;
+
             ResetMashing();
         }
     }
@@ -279,10 +281,7 @@ public static class GameStatsManager
         {
             MashingNote = note;
             MashedNum++;
-            if (MashedNum < note.GetMulHitHighThreshold())
-                return;
         }
-        ResetMashing();
     }
 
     public static void Init()

--- a/MuseDashInfo+/MuseDashInfo+.csproj
+++ b/MuseDashInfo+/MuseDashInfo+.csproj
@@ -33,8 +33,9 @@
     <PackageReference Include="Lib.Harmony" Version="2.2.2" />
   </ItemGroup>
 	
-  <Target Name="Copy" AfterTargets="Build" Condition="'$(MuseDash)' != ''">
-	<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(MuseDash)/Mods/" Condition="'$(Configuration)' == 'Debug'" />
+  <Target Name="Copy" AfterTargets="Build" Condition="'$(MD_DIRECTORY)' != ''">
+	<Copy SourceFiles="$(OutputPath)$(AssemblyName).dll" DestinationFolder="$(MD_DIRECTORY)/Mods/" Condition="'$(Configuration)' == 'Debug'" />
+    <Message Text="Copied DLL -&gt; $(MD_DIRECTORY)\Mods\$(AssemblyName).dll" Importance="High"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
Title is pretty self explanatory.

You only need to hit the amount returned by `MusicData.GetMulHitLowThreshold()` to not have the masher count as a miss. The counter was also reset every time the max was reached, making the counter start over, also causing a miss.

Also fixed the `AfterBuild` in the csproj (`MD_DIRECTORY` is the standard envvar) and ignored the `.idea` folder.