### PR TITLE
v3.0.5

### DIFF
--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -1,0 +1,96 @@
+name: Update Assets Branch
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-assets:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease }}
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Download Info+.dll from release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Use gh CLI to download Info+.dll
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern "Info+.dll"
+
+          if [ ! -f "Info+.dll" ]; then
+            echo "Error: Info+.dll not found in release assets"
+            exit 1
+          fi
+
+          echo "Successfully downloaded Info+.dll"
+
+      - name: Calculate SHA256 hash
+        id: hash
+        run: |
+          HASH=$(sha256sum "Info+.dll" | awk '{print $1}')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          echo "Calculated hash: $HASH"
+
+      - name: Update version.json
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          HASH="${{ steps.hash.outputs.hash }}"
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/Info+.dll"
+
+          jq -n \
+            --arg version "$VERSION" \
+            --arg hash "$HASH" \
+            --arg url "$DOWNLOAD_URL" \
+            '{
+              "Version": $version,
+              "DownloadURL": [
+                "https://mdip.leever.cn/Info+.dll",
+                $url
+              ],
+              "Hash": $hash
+            }' > version.json
+
+          echo "Updated version.json:"
+          cat version.json
+
+      - name: Push to assets branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Fetch all branches
+          git fetch origin assets:assets 2>/dev/null || true
+
+          # Create new orphan branch for clean push
+          git checkout --orphan assets-temp
+
+          # Remove all tracked files
+          git rm -rf . 2>/dev/null || true
+
+          # Add only the two files we need
+          git add version.json "Info+.dll"
+          git commit -m "Update to version ${{ steps.version.outputs.version }}"
+
+          # Force push to assets branch
+          git push -f origin assets-temp:assets
+
+          echo "Successfully pushed to assets branch"

--- a/src/Application/Services/Scoped/UI/BattleUIService.cs
+++ b/src/Application/Services/Scoped/UI/BattleUIService.cs
@@ -1,4 +1,6 @@
-﻿using Il2CppAssets.Scripts.UI.Panels;
+using Il2CppAssets.Scripts.UI.Panels;
+using Il2CppAssets.Scripts.PeroTools.Commons;
+using Il2CppAssets.Scripts.GameCore.Managers;
 using JetBrains.Annotations;
 using MDIP.Application.DependencyInjection;
 using MDIP.Application.Services.Global.Assets;
@@ -50,6 +52,12 @@ public class BattleUIService : IBattleUIService
 
     private bool _allowNativeZoomFollow;
     private float _autoShowEnableTime;
+
+    private bool _isMissToGreat;
+    private bool _isGreatToPerfect;
+    private float _skillOffset;
+    private bool _skillOffsetInitialized;
+
 
     private ScoreStyleType _scoreStyleType = ScoreStyleType.Unknown;
 
@@ -148,6 +156,11 @@ public class BattleUIService : IBattleUIService
             _allowNativeZoomFollow = false;
             _autoShowEnableTime = Time.time + AutoShowDelaySeconds;
 
+            _isMissToGreat = false;
+            _isGreatToPerfect = false;
+            _skillOffset = 0f;
+            _skillOffsetInitialized = false;
+
             _isInitialized = true;
         }
         catch (Exception ex)
@@ -160,6 +173,8 @@ public class BattleUIService : IBattleUIService
     {
         if (_isShutdown || !_isInitialized || _currentPanel == null || _scoreTransform == null)
             return;
+
+        UpdateSkillOffset();
 
         if (!NativeZoomInCompleted)
         {
@@ -219,6 +234,88 @@ public class BattleUIService : IBattleUIService
         }
 
         _previousY = CurrentY;
+    }
+
+    // Horizontal shift applied per visible auto-avoid skill icon.
+    private const float SkillIconWidth = 80f;
+
+    private void UpdateSkillOffset()
+    {
+        if (_isShutdown || !_isInitialized || TextObjectService?.TextUpperLeft == null)
+            return;
+
+        // Feature disabled: clear any offset previously applied so the text snaps back,
+        // and reset state so re-enabling mid-battle re-initializes cleanly.
+        if (!ConfigAccessor.Main.PushIndicatorOnSkill)
+        {
+            if (_skillOffsetInitialized || _skillOffset != 0f)
+            {
+                _skillOffset = 0f;
+                _isMissToGreat = false;
+                _isGreatToPerfect = false;
+                _skillOffsetInitialized = false;
+                ApplyUpperLeftPosition();
+            }
+            return;
+        }
+
+        var battleProperty = Singleton<BattleProperty>.instance;
+        if (battleProperty == null)
+            return;
+
+        if (!_skillOffsetInitialized)
+        {
+            _skillOffset = 0f;
+            _isMissToGreat = false;
+            _isGreatToPerfect = false;
+
+            if (battleProperty.missToGreat != 0)
+            {
+                _isMissToGreat = true;
+                _skillOffset += SkillIconWidth;
+            }
+            if (battleProperty.greatToPerfect != 0)
+            {
+                _isGreatToPerfect = true;
+                _skillOffset += SkillIconWidth;
+            }
+
+            _skillOffsetInitialized = true;
+            ApplyUpperLeftPosition();
+            return;
+        }
+
+        var changed = false;
+
+        if (_isMissToGreat && battleProperty.missToGreat < 1)
+        {
+            _skillOffset -= SkillIconWidth;
+            _isMissToGreat = false;
+            changed = true;
+        }
+
+        if (_isGreatToPerfect && battleProperty.greatToPerfect < 1)
+        {
+            _skillOffset -= SkillIconWidth;
+            _isGreatToPerfect = false;
+            changed = true;
+        }
+
+        if (changed)
+            ApplyUpperLeftPosition();
+    }
+
+    private void ApplyUpperLeftPosition()
+    {
+        var textObj = TextObjectService?.TextUpperLeft;
+        var config = ConfigAccessor.TextFieldUpperLeft;
+        if (textObj == null || config == null)
+            return;
+
+        textObj.transform.localPosition = new Vector3(
+            Constants.POS_UPPER_LEFT_TEXT.x + _skillOffset + config.OffsetX,
+            Constants.POS_UPPER_LEFT_TEXT.y + config.OffsetY,
+            Constants.POS_UPPER_LEFT_TEXT.z);
     }
 
     public void QueueApplyConfigChanges()
@@ -655,7 +752,10 @@ public class BattleUIService : IBattleUIService
             "InfoPlus_TextUpperLeft",
             () => ConfigAccessor.TextFieldUpperLeft,
             () => _currentPanel.Find("Up"),
-            () => Constants.POS_UPPER_LEFT_TEXT,
+            () => new Vector3(
+                Constants.POS_UPPER_LEFT_TEXT.x + _skillOffset,
+                Constants.POS_UPPER_LEFT_TEXT.y,
+                Constants.POS_UPPER_LEFT_TEXT.z),
             false,
             TextAnchor.UpperLeft,
             FontStyle.Normal,
@@ -800,6 +900,11 @@ public class BattleUIService : IBattleUIService
         MusicInfoUtils.BattleUIType = BattleUIItem.Unknown;
 
         _lastUiVisibleByDefault = null;
+
+        _isMissToGreat = false;
+        _isGreatToPerfect = false;
+        _skillOffset = 0f;
+        _skillOffsetInitialized = false;
 
         Interlocked.Exchange(ref _pendingApplyRequests, 0);
     }

--- a/src/Core/Domain/Configs/MainConfigs.cs
+++ b/src/Core/Domain/Configs/MainConfigs.cs
@@ -1,4 +1,4 @@
-﻿using MDIP.Core.Domain.Attributes;
+using MDIP.Core.Domain.Attributes;
 
 namespace MDIP.Core.Domain.Configs;
 
@@ -143,6 +143,11 @@ public class MainConfigs : ConfigBase
     [ConfigCommentZh("以模组计算的 Miss 数替代结算页面的 Miss 数")]
     [ConfigCommentEn("Show mod-calculated misses instead of game's default count on results screen")]
     public bool ReplaceResultsScreenMissCount { get; set; } = false;
+
+    [ConfigCommentZh("避让技能图标")]
+    [ConfigCommentEn("Shift the upper left info display to avoid overlapping skill icons")]
+    public bool PushIndicatorOnSkill { get; set; } = true;
+
 
     [ConfigCommentZh("启用UI显隐切换快捷键")]
     [ConfigCommentEn("Enable UI visibility toggle hotkey")]

--- a/src/Presentation/ModBuildInfo.cs
+++ b/src/Presentation/ModBuildInfo.cs
@@ -5,6 +5,6 @@ public static class ModBuildInfo
     public const string Name = "Info+";
     public const string Description = "Displays additional in-game infos";
     public const string Author = "KARPED1EM";
-    public const string Version = "3.0.4";
+    public const string Version = "3.0.5";
     public const string RepoLink = "https://github.com/MDMods/MuseDashInfoPlus";
 }

--- a/src/Presentation/Patches/PnlVictoryPatch.cs
+++ b/src/Presentation/Patches/PnlVictoryPatch.cs
@@ -1,6 +1,9 @@
-﻿using JetBrains.Annotations;
+﻿using Il2CppAssets.Scripts.GameCore.HostComponent;
+using JetBrains.Annotations;
 using MDIP.Application.DependencyInjection;
+using MDIP.Application.Services.Global.RuntimeData;
 using MDIP.Application.Services.Scoped.UI;
+using MDIP.Core.Utilities;
 
 namespace MDIP.Presentation.Patches;
 
@@ -9,8 +12,33 @@ internal static class PnlVictorySetDetailInfoPatch
 {
     private static void Postfix(PnlVictory __instance)
     {
-        VictoryScreenService?.OnSetDetailInfo(__instance);
+        if (VictoryScreenService != null)
+        {
+            VictoryScreenService.OnSetDetailInfo(__instance);
+            return;
+        }
+
+        // Fallback: save personal best when scoped service is unavailable (e.g. scope disposed during scene transition)
+        SavePersonalBestDirect();
+    }
+
+    private static void SavePersonalBestDirect()
+    {
+        if (RuntimeDataStore == null)
+            return;
+
+        var task = TaskStageTarget.instance;
+        if (task == null)
+            return;
+
+        var hash = MusicInfoUtils.CurMusicHash;
+        var acc = (float)Math.Round((double)(task.GetAccuracy() * 100f), 2);
+        var score = task.m_Score;
+
+        RuntimeDataStore.StorePersonalBestAccuracy(hash, acc);
+        RuntimeDataStore.StorePersonalBestScore(hash, score);
     }
 
     [UsedImplicitly] [Inject] public static IVictoryScreenService VictoryScreenService { get; set; }
+    [UsedImplicitly] [Inject] public static IRuntimeDataStore RuntimeDataStore { get; set; }
 }


### PR DESCRIPTION
## v3.0.5

- feat: text auto-avoids skill icons (#47) — upper-left info shifts to avoid overlapping active auto-avoid skill icons; adds `PushIndicatorOnSkill` config (default on)
- fix: save personal best on victory screen even when DI scope is unavailable
- workflow: add release-to-assets sync workflow (auto-updates `version.json` + `Info+.dll` on the assets branch when a release is published)
- ver: up to 3.0.5