### PR TITLE
v3.1.1

### DIFF
--- a/src/Globals/TextData.cs
+++ b/src/Globals/TextData.cs
@@ -26,7 +26,7 @@ internal static class TextData
 
         var main = Config.Main;
         UpdateCachedValue("{pbScore}", stats.History.Score.ToString());
-        UpdateCachedValue("{pbAcc}", $"{stats.History.Accuracy}%");
+        UpdateCachedValue("{pbAcc}", FormattableString.Invariant($"{stats.History.Accuracy:F2}%"));
         UpdateCachedValue("{total}", ((int)stats.AccuracyCalculationTotal).ToString());
         UpdateCachedValue("{song}", MusicInfoUtils.CurMusicName.TruncateByWidth(45));
         UpdateCachedValue("{level}", MusicInfoUtils.GetDifficultyLabel(main));

--- a/src/Presentation/ModBuildInfo.cs
+++ b/src/Presentation/ModBuildInfo.cs
@@ -5,6 +5,6 @@ public static class ModBuildInfo
     public const string Name = "Info+";
     public const string Description = "Displays additional in-game infos";
     public const string Author = "KARPED1EM";
-    public const string Version = "3.1.0";
+    public const string Version = "3.1.1";
     public const string RepoLink = "https://github.com/MDMods/MuseDashInfoPlus";
 }


### PR DESCRIPTION
Patch: fix personal-best accuracy display introduced in v3.1.0.

Since v3.1.0 reads the PB accuracy from the ecosystem's own store (a 0..1 float), the `{pbAcc}` placeholder printed the raw float — e.g. a 99.90% play stored as ~0.999 surfaces in float32 as `99.899994%`. Format it with Invariant `:F2` to match the live accuracy, so it reads `99.90%`. Display-only; the stored value keeps full precision for the new-best comparison.

- fix: format personal-best accuracy to 2 decimals ({pbAcc})
- ver: up to 3.1.1